### PR TITLE
ToJSON and FromJSON instances for PgJSON

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -137,6 +137,7 @@ import           Data.Hashable
 import qualified Data.List.NonEmpty as NE
 import           Data.Proxy
 import           Data.Scientific (Scientific, formatScientific, FPFormat(Fixed))
+import qualified Data.Serialize as DS
 import           Data.String
 import qualified Data.Text as T
 import           Data.Time (LocalTime)
@@ -719,6 +720,20 @@ instance ToJSON a => HasSqlValueSyntax PgValueSyntax (PgJSON a) where
   sqlValueSyntax (PgJSON a) =
     PgValueSyntax $
     emit "'" <> escapeString (BL.toStrict (encode a)) <> emit "'::json"
+
+instance (ToJSON a) => ToJSON (PgJSON a) where
+  toJSON (PgJSON x) = toJSON x
+
+instance (FromJSON a) => FromJSON (PgJSON a) where
+  parseJSON v = PgJSON <$> parseJSON v
+
+instance (ToJSON a, FromJSON a) => DS.Serialize (PgJSON a) where
+  put (PgJSON x) = DS.put (BL.toStrict (Data.Aeson.encode x))
+  get = do
+    bs <- DS.get @BL.ByteString
+    case Data.Aeson.eitherDecode bs of
+      Left err -> fail ("Failed to deserialize PgJSON: " ++ err)
+      Right x  -> pure (PgJSON x)
 
 -- | The Postgres @JSONB@ type, which stores JSON-encoded data in a
 -- postgres-specific binary format. Like 'PgJSON', the type parameter indicates

--- a/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
+++ b/beam-postgres/Database/Beam/Postgres/PgSpecific.hs
@@ -137,7 +137,6 @@ import           Data.Hashable
 import qualified Data.List.NonEmpty as NE
 import           Data.Proxy
 import           Data.Scientific (Scientific, formatScientific, FPFormat(Fixed))
-import qualified Data.Serialize as DS
 import           Data.String
 import qualified Data.Text as T
 import           Data.Time (LocalTime)
@@ -726,14 +725,6 @@ instance (ToJSON a) => ToJSON (PgJSON a) where
 
 instance (FromJSON a) => FromJSON (PgJSON a) where
   parseJSON v = PgJSON <$> parseJSON v
-
-instance (ToJSON a, FromJSON a) => DS.Serialize (PgJSON a) where
-  put (PgJSON x) = DS.put (BL.toStrict (Data.Aeson.encode x))
-  get = do
-    bs <- DS.get @BL.ByteString
-    case Data.Aeson.eitherDecode bs of
-      Left err -> fail ("Failed to deserialize PgJSON: " ++ err)
-      Right x  -> pure (PgJSON x)
 
 -- | The Postgres @JSONB@ type, which stores JSON-encoded data in a
 -- postgres-specific binary format. Like 'PgJSON', the type parameter indicates

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -57,7 +57,8 @@ library
                       tagged               >=0.8  && <0.9,
 
                       haskell-src-exts     >=1.18 && <1.22,
-                      clock
+                      clock,
+                      cereal
   default-language:   Haskell2010
   default-extensions: ScopedTypeVariables, OverloadedStrings, MultiParamTypeClasses, RankNTypes, FlexibleInstances,
                       DeriveDataTypeable, DeriveGeneric, StandaloneDeriving, TypeFamilies, GADTs, OverloadedStrings,

--- a/beam-postgres/beam-postgres.cabal
+++ b/beam-postgres/beam-postgres.cabal
@@ -57,8 +57,7 @@ library
                       tagged               >=0.8  && <0.9,
 
                       haskell-src-exts     >=1.18 && <1.22,
-                      clock,
-                      cereal
+                      clock
   default-language:   Haskell2010
   default-extensions: ScopedTypeVariables, OverloadedStrings, MultiParamTypeClasses, RankNTypes, FlexibleInstances,
                       DeriveDataTypeable, DeriveGeneric, StandaloneDeriving, TypeFamilies, GADTs, OverloadedStrings,


### PR DESCRIPTION
Added ToJSON and FromJSON instances for PgJSON, to be used for making strict, uniform types in Newton using PgJSON.
PR FYR: https://bitbucket.juspay.net/projects/AX/repos/newton-hs/pull-requests/3541/diff#src/Newton/Types/Storage/Transaction.hs